### PR TITLE
feat: resolve window.google

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Using a promise for when the script has loaded.
 // Promise
 loader
   .load()
-  .then(() => {
+  .then((google) => {
     new google.maps.Map(document.getElementById("map"), mapOptions);
   })
   .catch(e => {

--- a/examples/index.html
+++ b/examples/index.html
@@ -61,7 +61,7 @@
       // Promise
       loader
         .load()
-        .then(() => {
+        .then((google) => {
           new google.maps.Map(document.getElementById("map"), mapOptions);
         })
         .catch((e) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -292,8 +292,9 @@ test("loader should resolve immediately when successfully loaded", async () => {
   // use await/async pattern since the promise resolves without trigger
   const loader = new Loader({ apiKey: "foo", retries: 0 });
   loader["done"] = true;
-
-  await expect(loader.loadPromise()).resolves.toBeUndefined();
+  // TODO causes warning
+  window.google = { maps: { version: "3.*.*" } as any };
+  await expect(loader.loadPromise()).resolves.toBeDefined();
 });
 
 test("loader should resolve immediately when failed loading", async () => {
@@ -324,7 +325,7 @@ test("loader should resolve immediately when google.maps defined", async () => {
   const loader = new Loader({ apiKey: "foo" });
   window.google = { maps: { version: "3.*.*" } as any };
   console.warn = jest.fn();
-  await expect(loader.loadPromise()).resolves.toBeUndefined();
+  await expect(loader.loadPromise()).resolves.toBeDefined();
   delete window.google;
   expect(console.warn).toHaveBeenCalledTimes(1);
 });
@@ -334,7 +335,7 @@ test("loader should not warn if done and google.maps is defined", async () => {
   loader["done"] = true;
   window.google = { maps: { version: "3.*.*" } as any };
   console.warn = jest.fn();
-  await expect(loader.loadPromise()).resolves.toBeUndefined();
+  await expect(loader.loadPromise()).resolves.toBeDefined();
   delete window.google;
   expect(console.warn).toHaveBeenCalledTimes(0);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,7 +180,7 @@ export interface LoaderOptions {
  *   libraries: ["places"]
  * });
  *
- * loader.load().then(() => {
+ * loader.load().then((google) => {
  *   const map = new google.maps.Map(...)
  * })
  * ```
@@ -367,7 +367,7 @@ export class Loader {
   /**
    * Load the Google Maps JavaScript API script and return a Promise.
    */
-  load(): Promise<void> {
+  load(): Promise<typeof google> {
     return this.loadPromise();
   }
 
@@ -376,11 +376,11 @@ export class Loader {
    *
    * @ignore
    */
-  loadPromise(): Promise<void> {
+  loadPromise(): Promise<typeof google> {
     return new Promise((resolve, reject) => {
       this.loadCallback((err: Event) => {
         if (!err) {
-          resolve();
+          resolve(window.google);
         } else {
           reject(err);
         }


### PR DESCRIPTION
closes #224 by resolving to `window.google`

```javascript
loader
  .load()
  .then((google) => {
    new google.maps.Map(document.getElementById("map"), mapOptions);
  })
  .catch(e => {
    // do something
  });
```