### PR TITLE
fix: add loading=async to the urls with callbacks

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,7 +25,10 @@ afterEach(() => {
 });
 
 test.each([
-  [{}, "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async"],
+  [
+    {},
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async",
+  ],
   [
     { apiKey: "foo" },
     "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&key=foo",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,10 +25,10 @@ afterEach(() => {
 });
 
 test.each([
-  [{}, "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback"],
+  [{}, "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async"],
   [
     { apiKey: "foo" },
-    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&key=foo",
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&key=foo",
   ],
   [
     {
@@ -38,23 +38,23 @@ test.each([
       language: "language",
       region: "region",
     },
-    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&key=foo&libraries=marker,places&language=language&region=region&v=weekly",
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&key=foo&libraries=marker,places&language=language&region=region&v=weekly",
   ],
   [
     { mapIds: ["foo", "bar"] },
-    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&map_ids=foo,bar",
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&map_ids=foo,bar",
   ],
   [
     { url: "https://example.com/js" },
-    "https://example.com/js?callback=__googleMapsCallback",
+    "https://example.com/js?callback=__googleMapsCallback&loading=async",
   ],
   [
     { client: "bar", channel: "foo" },
-    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&channel=foo&client=bar",
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&channel=foo&client=bar",
   ],
   [
     { authReferrerPolicy: "origin" },
-    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&auth_referrer_policy=origin",
+    "https://maps.googleapis.com/maps/api/js?callback=__googleMapsCallback&loading=async&auth_referrer_policy=origin",
   ],
 ])("createUrl is correct", (options: LoaderOptions, expected: string) => {
   const loader = new Loader(options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,7 +369,7 @@ export class Loader {
   public createUrl(): string {
     let url = this.url;
 
-    url += `?callback=__googleMapsCallback`;
+    url += `?callback=__googleMapsCallback&loading=async`;
 
     if (this.apiKey) {
       url += `&key=${this.apiKey}`;


### PR DESCRIPTION
This PR adds `loading=async` as a combination with the `callback` parameter to resolve the warning message.

From the Discord:
> hello, do you guys know how to get rid off the warning below while using APIProvider component from '@vis.gl/react-google-maps' ? I don't see there any flag to set regarding loading type, obviously I could load the maps in old vanilla JS way but it's not a point while I have installed the library package 😦 

> "Google Maps JavaScript API has been loaded directly without loading=async. This can result in suboptimal performance. For best-practice loading patterns please see https://goo.gle/js-api-loading"


From the documentation:
> loading: The code loading strategy that the Maps JavaScript API can use. Set to async to indicate that the Maps JavaScript API has not been loaded synchronously and that no JavaScript code is triggered by the script's load event. It is highly recommended to set this to async whenever possible, for improved performance. (Use the callback parameter instead to perform actions when the Maps JavaScript API is available.) Available starting with version 3.55.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
