### PR TITLE
fix: change filename for esm build to use .mjs extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Justin Poehnelt",
   "main": "dist/index.umd.js",
   "unpkg": "dist/index.min.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "types": "dist/src/index.d.ts",
   "files": [
     "dist/",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -88,7 +88,7 @@ export default [
       commonjs(),
     ],
     output: {
-      file: "dist/index.esm.js",
+      file: "dist/index.mjs",
       format: "esm",
       sourcemap: true,
     },


### PR DESCRIPTION
Don't have the time to investigate why this happened right now, but for some reason webpack needs a .mjs file extension for esm files. Maybe this was caused by adding `"type": "commonjs"` to the package.json?

Fixes the webpack error-message reported by @samuelcole and @martincostello in #825.