### PR TITLE
fix: rollup/typescript configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,16 @@
       "version": "1.16.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@rollup/plugin-terser": "^0.4.3",
         "fast-deep-equal": "^3.1.3"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.9.5",
+        "@babel/preset-modules": "^0.1.6",
         "@babel/runtime-corejs3": "^7.9.2",
         "@rollup/plugin-babel": "^6.0.3",
         "@rollup/plugin-commonjs": "^25.0.4",
         "@rollup/plugin-node-resolve": "^15.2.1",
+        "@rollup/plugin-terser": "^0.4.3",
         "@rollup/plugin-typescript": "^11.1.4",
         "@types/google.maps": "^3.53.1",
         "@types/jest": "^29.5.5",
@@ -529,6 +530,23 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
+      "integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-unicode-property-regex instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1677,13 +1695,29 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-modules": {
+    "node_modules/@babel/preset-env/node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
       "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-modules": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6.tgz",
+      "integrity": "sha512-ID2yj6K/4lKfhuU3+EX4UvNbIt7eACFbHmNUjzA+ep+B5971CknnA/9DEWKbRokfbbtblxxxXFJJrH47UEAMVg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
       },
@@ -2653,6 +2687,7 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
       "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2666,6 +2701,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2674,6 +2710,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2682,6 +2719,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2690,12 +2728,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.20",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
       "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2836,6 +2876,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
       "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+      "dev": true,
       "dependencies": {
         "serialize-javascript": "^6.0.1",
         "smob": "^1.0.0",
@@ -3628,6 +3669,7 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4113,7 +4155,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
     },
     "node_modules/buffer-indexof-polyfill": {
       "version": "1.0.2",
@@ -4314,7 +4357,8 @@
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -9040,6 +9084,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -9256,7 +9301,7 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.6.1.tgz",
       "integrity": "sha512-jZHaZotEHQaHLgKr8JnQiDT1rmatjgKlMekyksz+yk9jt/8z9quNjnKNRoaM0wd9DC2QKXjmWWuDYtM3jfF8pQ==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -9321,7 +9366,8 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -9368,6 +9414,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
       "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -9435,12 +9482,14 @@
     "node_modules/smob": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
-      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ=="
+      "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9642,6 +9691,7 @@
       "version": "5.25.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.25.0.tgz",
       "integrity": "sha512-we0I9SIsfvNUMP77zC9HG+MylwYYsGFSBG8qm+13oud2Yh+O104y614FRbyjpxys16jZwot72Fpi827YvGzuqg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -9659,6 +9709,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "main": "dist/index.umd.js",
   "unpkg": "dist/index.min.js",
   "module": "dist/index.mjs",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist/",
     "src/"
@@ -33,9 +33,7 @@
     "test": "jest src/*",
     "test:e2e": "jest e2e/*"
   },
-  "dependencies": {
-    "fast-deep-equal": "^3.1.3"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/preset-env": "^7.9.5",
     "@babel/runtime-corejs3": "^7.9.2",
@@ -54,6 +52,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jest": "^27.4.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "fast-deep-equal": "^3.1.3",
     "geckodriver": "^4.2.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,71 +20,55 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 
-const babelOptions = {
-  extensions: [".js", ".ts"],
-};
-
-const terserOptions = { output: { comments: "" } };
-
-const resolveOptions = {
-  mainFields: ["browser", "jsnext:main", "module", "main"],
+const terserOptions = {
+  output: { comments: "some" },
 };
 
 export default [
+  // UMD and browser (iife) builds
   {
     input: "src/index.ts",
     plugins: [
-      typescript({ tsconfig: "./tsconfig.json", declarationDir: "./" }),
-
-      nodeResolve(resolveOptions),
+      typescript({ tsconfig: "./tsconfig.build.json", declarationDir: "./" }),
+      nodeResolve({
+        mainFields: ["browser", "jsnext:main", "module", "main"],
+      }),
       commonjs(),
-      babel(babelOptions),
-      terser(terserOptions),
+      babel({
+        extensions: [".js", ".ts"],
+        babelHelpers: "bundled",
+      }),
     ],
-    output: {
-      file: "dist/index.umd.js",
-      format: "umd",
-      name: "google.maps.plugins.loader",
-      sourcemap: true,
-    },
+    output: [
+      {
+        file: "dist/index.umd.js",
+        format: "umd",
+        name: "google.maps.plugins.loader",
+        sourcemap: true,
+        plugins: [terser(terserOptions)],
+      },
+      {
+        file: "dist/index.min.js",
+        format: "iife",
+        name: "google.maps.plugins.loader",
+        sourcemap: true,
+        plugins: [terser(terserOptions)],
+      },
+      {
+        file: "dist/index.dev.js",
+        format: "iife",
+        name: "google.maps.plugins.loader",
+        sourcemap: true,
+      },
+    ],
   },
+
+  // ESM build
   {
     input: "src/index.ts",
     plugins: [
-      typescript({ tsconfig: "./tsconfig.json", declarationDir: "./" }),
-
-      nodeResolve(resolveOptions),
-      commonjs(),
-      babel(babelOptions),
-      terser(terserOptions),
-    ],
-    output: {
-      file: "dist/index.min.js",
-      format: "iife",
-      name: "google.maps.plugins.loader",
-    },
-  },
-  {
-    input: "src/index.ts",
-    plugins: [
-      typescript({ tsconfig: "./tsconfig.json", declarationDir: "./" }),
-
-      nodeResolve(resolveOptions),
-      commonjs(),
-      babel(babelOptions),
-    ],
-    output: {
-      file: "dist/index.dev.js",
-      format: "iife",
-      name: "google.maps.plugins.loader",
-    },
-  },
-  {
-    input: "src/index.ts",
-    plugins: [
-      typescript({ tsconfig: "./tsconfig.json", declarationDir: "./" }),
-
-      nodeResolve(resolveOptions),
+      typescript({ tsconfig: "./tsconfig.build.json", declarationDir: "./" }),
+      nodeResolve(),
       commonjs(),
     ],
     output: {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "./dist", "./e2e", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
This is a full refactoring of the rollup configuration to speed up builds, simplify the configuration, prevent warnings and fix an error with the generated source maps.

In detail:
 - refactor: Combine the three non-esm outputs into a single configuration.

 - refactor: add `{babelHelpers:'bundled'}` to configuration. This doesn't change the behavior (since it's the default if unspecified), but it prevents the corresponding warning from showing up.

 - feat: Enabled source-maps for all build outputs.

 - fix: Use a separate TypeScript configuration (`tsconfig.build.json`) during build. This configuration only compiles the required typescript files and doesn't reproduce the directory structure in the dist-folder (see also the change in package.json). It also now generates source maps correctly (#834).

 - chore: Moved `fast-deep-equal` from dependencies to devDependencies. It is a very small function, and it has always been bundled in all of our outputs, so it's not actually required at runtime. This will be changed in the next major release.

 fixes #834