### PR TITLE
chore: update github actions to latest versions

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies
@@ -35,11 +35,11 @@ jobs:
 
       - if: github.ref == 'refs/heads/main'
         name: Publish to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
 
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs
-          user_name: 'googlemaps-bot'
-          user_email: 'googlemaps-bot@users.noreply.github.com'
+          user_name: "googlemaps-bot"
+          user_email: "googlemaps-bot@users.noreply.github.com"
           commit_message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
   chrome:
     runs-on: ubuntu-latest
     services:
-       hub:
+      hub:
         image: selenium/standalone-chrome
         volumes:
           - ${{ github.workspace }}:${{ github.workspace }}
@@ -33,9 +33,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,13 +32,11 @@ jobs:
     steps:
       - id: release
         name: Release Please
-        uses: google-github-actions/release-please-action@v3
+        uses: googleapis/release-please-action@v4
 
         with:
           release-type: node
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
-          package-name: "@googlemaps/api-loader"
-          bump-minor-pre-major: true
 
       # Everything below is for NPM publishing when a release is cut.
       # Note the "if" statement on all commands to make sure that publishing
@@ -46,7 +44,7 @@ jobs:
 
       - if: ${{ steps.release.outputs.release_created }}
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - if: ${{ steps.release.outputs.release_created }}
         name: Setup Node for Dependency Installation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          node-version: 22
+          cache: npm
       - run: npm i
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
Update all github actions used in our workflows to the respective latest version and update the used node version to v22.