### PR TITLE
chore: add contents:write permission for pushing to gh-pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,9 +14,14 @@
 
 name: Docs
 on: [push, pull_request]
+
 jobs:
   docs:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
My previous PR surfaced another issue: the docs.yml workflow now needs extra permissions to be able to write to the gh-pages branch. This PR should fix that.