### PR TITLE
fix: add `sideEffects` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "require": "./dist/index.cjs",
     "types": "./dist/index.d.ts"
   },
+  "sideEffects": [
+    "dist/index.js",
+    "dist/index.cjs"
+  ],
   "files": [
     "dist/",
     "src/"


### PR DESCRIPTION
Add explicit `sideEffects` to the package.json to prevent aggressively optimizing bundlers from removing setOptions from the bundle.

See: #1083