### PR TITLE
chore: update and simplify rollup configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,9 +3,6 @@
     [
       "@babel/env",
       {
-        "targets": {
-          "browsers": "ie>=11, > 0.25%, not dead"
-        },
         "corejs": "3.6",
         "useBuiltIns": "usage"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prepack": "npm run build",
     "lint": "eslint .",
     "test": "NODE_OPTIONS='--experimental-vm-modules --disable-warning=ExperimentalWarning' jest ./src",
-    "build": "rm -rf ./dist && rollup -c && rm -rf ./dist/types",
+    "build": "rm -rf ./dist && rollup -c",
     "format": "eslint . --fix"
   },
   "dependencies": {
@@ -76,5 +76,9 @@
   },
   "prettier": {
     "trailingComma": "es5"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "not dead"
+  ]
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,26 +28,23 @@ const terserOptions = {
 
 const basePlugins = [
   typescript({
+    declaration: false,
     tsconfig: "./tsconfig.build.json",
-    declaration: true,
-    declarationDir: "dist/types",
   }),
-  nodeResolve({
-    mainFields: ["browser", "jsnext:main", "module", "main"],
-  }),
+  nodeResolve(),
   commonjs(),
-  babel({
-    extensions: [".js", ".ts"],
-    babelHelpers: "bundled",
-  }),
 ];
 
 export default [
-  // UMD and browser (iife) builds
+  // CJS/UMD build
   {
     input: "src/index.ts",
     plugins: [
       ...basePlugins,
+      babel({
+        extensions: [".js", ".ts"],
+        babelHelpers: "bundled",
+      }),
       replace({
         preventAssignment: true,
         values: {
@@ -66,16 +63,12 @@ export default [
       },
     ],
   },
+
   // ESM build
   {
     input: "src/index.ts",
     plugins: [
-      typescript({
-        tsconfig: "./tsconfig.build.json",
-        declaration: false,
-      }),
-      nodeResolve(),
-      commonjs(),
+      ...basePlugins,
       replace({
         preventAssignment: true,
         values: {
@@ -90,9 +83,10 @@ export default [
       exports: "named",
     },
   },
+
   // types
   {
-    input: "./dist/types/index.d.ts",
+    input: "src/index.ts",
     output: [{ file: "dist/index.d.ts", format: "es" }],
     plugins: [dts()],
   },


### PR DESCRIPTION
This updates the browser list to be more in line with the official browser support policy of the Google Maps JavaScript API and simplifies the rollup configuration and build process.
