### PR TITLE
fix: add warning message about common "apiKey" misspelling

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -16,6 +16,7 @@
 
 import { jest } from "@jest/globals";
 import type { bootstrap } from "./bootstrap.js";
+import type { APIOptions } from "./index.js";
 
 type ImportLibraryMock = jest.Mock<typeof google.maps.importLibrary>;
 
@@ -79,6 +80,17 @@ describe("importLibrary(): basic operation", () => {
     await importLibrary("maps");
 
     expect(mockBootstrap).toHaveBeenCalledWith(options);
+  });
+
+  it("should log a warning when apiKey is used and use it as key", async () => {
+    const { setOptions } = await import("./index.js");
+    const { logDevWarning, MSG_API_KEY_USED } = await import("./messages.js");
+
+    const options = { apiKey: "foo" } as unknown as APIOptions;
+    setOptions(options);
+
+    expect(logDevWarning).toHaveBeenCalledWith(MSG_API_KEY_USED);
+    expect(options.key).toBe("foo");
   });
 
   it("should return the value from importLibrary", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   MSG_SCRIPT_ELEMENT_EXISTS,
   MSG_REPEATED_SET_OPTIONS,
   MSG_SET_OPTIONS_NOT_CALLED,
+  MSG_API_KEY_USED,
 } from "./messages.js";
 
 export type APIOptions = {
@@ -80,6 +81,14 @@ export function setOptions(options: APIOptions) {
     logDevWarning(MSG_REPEATED_SET_OPTIONS(options));
 
     return;
+  }
+
+  if ((options as Record<string, unknown>).apiKey) {
+    logDevWarning(MSG_API_KEY_USED);
+
+    if (!options.key) {
+      options.key = (options as Record<string, unknown>).apiKey as string;
+    }
   }
 
   installImportLibrary_(options);

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -44,6 +44,10 @@ export const MSG_SCRIPT_ELEMENT_EXISTS =
   "problems using the API. Make sure to remove the script " +
   "loading the API.";
 
+export const MSG_API_KEY_USED =
+  "The 'apiKey' parameter was used in setOptions(), but 'key' is the correct " +
+  "parameter name. Please update your configuration.";
+
 // Development mode check - bundlers will replace process.env.NODE_ENV at build time
 declare const process: { env: { NODE_ENV?: string } };
 const __DEV__ = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
AI Agents will often use the old `apiKey`  option name instead of the new `key`. This adds a warning message for this special case.